### PR TITLE
Feat: Construct Gandalf workshop scaffold

### DIFF
--- a/gandalf_workshop/__init__.py
+++ b/gandalf_workshop/__init__.py
@@ -1,0 +1,16 @@
+"""
+Gandalf Workshop Package Root
+
+This file makes the 'gandalf_workshop' directory a Python package.
+It's like placing a sign on the main workshop building, identifying it
+and allowing its various departments (submodules) to be recognized
+and accessed systematically.
+"""
+# You can make key components available at the package level if desired, e.g.:
+# from .workshop_manager import WorkshopManager
+# from .specs.data_models import BlueprintModel, InspectionReportModel
+
+__version__ = "0.1.0"  # Workshop's current "model year" or "version"
+PROJECT_NAME = "Gandalf Workshop"
+
+print(f"Welcome to {PROJECT_NAME} v{__version__}. The workshop is now open.")

--- a/gandalf_workshop/artisan_guildhall/__init__.py
+++ b/gandalf_workshop/artisan_guildhall/__init__.py
@@ -1,0 +1,28 @@
+"""
+Gandalf Workshop - Artisan Guildhall Submodule
+
+This file makes the 'artisan_guildhall' directory a Python submodule.
+This is the "Artisan's Guildhall" itself, containing the charters (prompts)
+that guide the Artisans and the means to assemble (initialize) them for work.
+Making it a submodule allows for organized access to these core agent-related
+components.
+"""
+from .prompts import (
+    PLANNER_CHARTER_PROMPT,
+    CODER_CHARTER_PROMPT,
+    GENERAL_INSPECTOR_CHARTER_PROMPT
+)
+from .artisans import (
+    initialize_planning_crew,
+    initialize_coding_crew,
+    initialize_inspection_crew
+)
+
+__all__ = [
+    "PLANNER_CHARTER_PROMPT",
+    "CODER_CHARTER_PROMPT",
+    "GENERAL_INSPECTOR_CHARTER_PROMPT",
+    "initialize_planning_crew",
+    "initialize_coding_crew",
+    "initialize_inspection_crew"
+]

--- a/gandalf_workshop/artisan_guildhall/artisans.py
+++ b/gandalf_workshop/artisan_guildhall/artisans.py
@@ -53,7 +53,6 @@ def initialize_planning_crew():
     # )
     # return planning_crew
     print("Artisan Assembly: Planning Crew initialized (placeholder).")
-    pass
 
 
 def initialize_coding_crew():
@@ -90,7 +89,6 @@ def initialize_coding_crew():
     # )
     # return coding_crew
     print("Artisan Assembly: Coding Crew initialized (placeholder).")
-    pass
 
 
 def initialize_inspection_crew():
@@ -130,7 +128,6 @@ def initialize_inspection_crew():
     # )
     # return inspection_crew
     print("Artisan Assembly: Inspection Crew initialized (placeholder).")
-    pass
 
 
 if __name__ == '__main__':

--- a/gandalf_workshop/artisan_guildhall/artisans.py
+++ b/gandalf_workshop/artisan_guildhall/artisans.py
@@ -1,0 +1,141 @@
+"""
+artisans.py - The Assembly Hall for Specialist Artisan Crews
+
+This module provides functions to initialize and configure the various "Artisan Crews"
+(specialized AI agent teams). Think of this as the workshop's assembly hall where
+the Workshop Manager gathers and briefs the required craftsmen (Planner, Coder, Inspector crews)
+before they embark on their assigned tasks for a commission. Each function here would
+typically set up an agent or a team of agents (e.g., using CrewAI, AutoGen, or LangGraph)
+with their respective charters, tools, and any commission-specific context.
+"""
+
+# from .prompts import (PLANNER_CHARTER_PROMPT, CODER_CHARTER_PROMPT,
+#                       GENERAL_INSPECTOR_CHARTER_PROMPT)
+# Import necessary AI framework components here, e.g.:
+# from crewai import Agent, Task, Crew, Process
+
+# Metaphor: These functions are like the Workshop Manager's assistants
+# who know how to quickly assemble a team of Planners, Coders, or
+# Inspectors, providing them with their official charters (prompts) and
+# tools.
+
+
+def initialize_planning_crew():
+    """
+    Assembles and initializes a "Planning Crew" of AI agents.
+    Metaphor: Gathers the Master Draftsmen and Architectural Scribes in the
+    Design Studio, handing them their charter and tools to create a new
+    Blueprint.
+
+    This crew would be responsible for taking a user prompt and generating
+    a detailed `blueprint.yaml` file.
+    """
+    # Placeholder for actual crew initialization (e.g., CrewAI setup)
+    # Example (conceptual):
+    # planner_agent = Agent(
+    #   role='Lead Blueprint Architect',
+    #   goal='Create a comprehensive and actionable blueprint from a user '
+    #        'request.',
+    #   backstory='A seasoned architect renowned for clarity and foresight '
+    #             'in design.',
+    #   instructions=PLANNER_CHARTER_PROMPT,
+    #   verbose=True
+    # )
+    # planning_task = Task(
+    #   description='Analyze the user request and generate a blueprint.yaml '
+    #               'file.',
+    #   agent=planner_agent
+    # )
+    # planning_crew = Crew(
+    #   agents=[planner_agent],
+    #   tasks=[planning_task],
+    #   process=Process.sequential
+    # )
+    # return planning_crew
+    print("Artisan Assembly: Planning Crew initialized (placeholder).")
+    pass
+
+
+def initialize_coding_crew():
+    """
+    Assembles and initializes a "Coding Crew" of AI agents.
+    Metaphor: Summons the Master Builders and Code Smiths to the Main
+    Workbench, providing them with the Blueprint and tools to construct the
+    Product.
+
+    This crew takes a `blueprint.yaml` and (optionally) an
+    `inspection_report.json` to generate or revise the product code.
+    """
+    # Placeholder for actual crew initialization
+    # Example (conceptual):
+    # coder_agent = Agent(
+    #   role='Lead Software Artisan',
+    #   goal='Implement the product specifications from the blueprint and '
+    #        'address any reported flaws.',
+    #   backstory='A meticulous craftsman dedicated to producing high-quality, '
+    #             'functional code.',
+    #   instructions=CODER_CHARTER_PROMPT,
+    #   verbose=True
+    # )
+    # # ... more agents for testing, specific component development etc.
+    # coding_task = Task(
+    #   description='Develop or revise the product based on the blueprint and '
+    #               'inspection report.',
+    #   agent=coder_agent
+    # )
+    # coding_crew = Crew(
+    #   agents=[coder_agent], # Potentially more agents
+    #   tasks=[coding_task],
+    #   process=Process.sequential
+    # )
+    # return coding_crew
+    print("Artisan Assembly: Coding Crew initialized (placeholder).")
+    pass
+
+
+def initialize_inspection_crew():
+    """
+    Assembles and initializes an "Inspection Crew" of AI agents.
+    Metaphor: Calls upon the Guild of Quality Assessors and Scrutineers
+    to the Quality Control Lab, tasking them with examining a Product
+    against its Blueprint.
+
+    This crew takes a product and its `blueprint.yaml` to produce an
+    `inspection_report.json`. It might include various specialized
+    inspectors.
+    """
+    # Placeholder for actual crew initialization
+    # Example (conceptual):
+    # lead_inspector_agent = Agent(
+    #   role='Chief Quality Inspector',
+    #   goal='Conduct a thorough inspection of the product against its '
+    #        'blueprint and generate a detailed inspection report.',
+    #   backstory='An uncompromising guardian of quality with an eagle eye '
+    #             'for detail.',
+    #   instructions=GENERAL_INSPECTOR_CHARTER_PROMPT,  # May be specialized
+    #   verbose=True
+    # )
+    # # Could add more specialized inspector agents here (e.g., security,
+    # # compliance)
+    # inspection_task = Task(
+    #   description='Inspect the submitted product against the blueprint and '
+    #               'document all findings.',
+    #   agent=lead_inspector_agent
+    # )
+    # inspection_crew = Crew(
+    #   agents=[lead_inspector_agent],  # Potentially more specialized
+    #                                   # inspectors
+    #   tasks=[inspection_task],
+    #   process=Process.sequential
+    # )
+    # return inspection_crew
+    print("Artisan Assembly: Inspection Crew initialized (placeholder).")
+    pass
+
+
+if __name__ == '__main__':
+    print("Attempting to initialize artisan crews (placeholders):")
+    initialize_planning_crew()
+    initialize_coding_crew()
+    initialize_inspection_crew()
+    print("Initialization calls completed.")

--- a/gandalf_workshop/artisan_guildhall/prompts.py
+++ b/gandalf_workshop/artisan_guildhall/prompts.py
@@ -1,0 +1,104 @@
+"""
+prompts.py - The Guild Library of Artisan Charters
+
+This module stores the official "Charters" for each type of Specialist
+Artisan in the Gandalf Workshop. These charters are essentially detailed role
+descriptions and instructions, akin to the scrolls or rulebooks kept in a
+medieval guild's library, defining the responsibilities and methods of its
+craftsmen. They serve as the foundational prompts or system messages when
+initializing AI agent crews for specific tasks.
+"""
+
+# Metaphor: These are the official scrolls from the Guild Library, each
+# detailing the sacred duties and methods of an artisan type.
+
+PLANNER_CHARTER_PROMPT = """
+Your mission is to act as a Planner Artisan. You have received a new
+Commission Brief. Your goal is to produce a comprehensive `blueprint.yaml`
+file.
+
+1.  **Understand the Request:** Read the Commission Brief carefully. Identify
+    the core problem and the desired outcome.
+2.  **Ask Clarifying Questions (if this were interactive):** Imagine what you
+    would ask the client to resolve ambiguities.
+3.  **Structure Your Blueprint:**
+    *   Populate `commission_id`, `commission_title`, `commission_type`.
+    *   Write a clear `project_summary` and list `key_objectives`.
+    *   Detail the `product_specifications`:
+        *   If `commission_type: software_mvp`: Define `target_platform`,
+            `primary_language_framework`, break down into `modules` with
+            `components` and their `requirements`. List `dependencies` and
+            essential `unit_tests_required`.
+        *   If `commission_type: research_report`: Define the
+            `report_structure` with `section_title`,
+            `key_questions_to_address`, and `required_subsections`. List any
+            `key_sources_to_consult` and the required `citation_style`.
+    *   Define `quality_criteria` and `acceptance_criteria` that will be
+        used by Inspector Artisans.
+4.  **Output:** Produce ONLY the `blueprint.yaml` content, adhering strictly
+    to the official schema. Do not add conversational text outside the YAML.
+"""
+
+CODER_CHARTER_PROMPT = """
+Your mission is to act as a Coder Artisan. You have been given a
+`blueprint.yaml`. You may also receive an `inspection_report.json` if this
+is a revision task.
+
+1.  **Study the Blueprint:** Understand all requirements, modules, components,
+    and tests defined.
+2.  **If Revising:** Carefully examine the `identified_flaws` in the
+    `inspection_report.json`. Prioritize addressing critical and
+    high-severity flaws.
+3.  **Implement the Code:**
+    *   Create the directory structure for the Product as implied by the
+        Blueprint.
+    *   Write the code for each module/component.
+    *   Follow specified languages, frameworks, and coding standards.
+4.  **Write and Run Unit Tests (for software):**
+    *   Implement all tests listed in
+        `blueprint.yaml.product_specifications.unit_tests_required`.
+    *   Run `pytest` (or the relevant test runner) and ensure all tests pass.
+    *   Run linters (e.g., `flake8`) and resolve all errors.
+5.  **Prepare for Inspection:** Ensure the Product is complete according to the
+    Blueprint and ready for the Inspector Artisans.
+6.  **Output:** Provide the complete codebase for the Product.
+"""
+
+GENERAL_INSPECTOR_CHARTER_PROMPT = """
+Your mission is to act as an Inspector Artisan. You have received a Product
+and its `blueprint.yaml`. Your goal is to produce a comprehensive
+`inspection_report.json`.
+
+1.  **Understand the Blueprint:** This is your reference for what the Product
+    *should* be.
+2.  **Examine the Product:** Apply your specific inspection techniques (refer
+    to specialized charters if applicable for detailed methods like security
+    scanning, citation validation, etc.).
+3.  **Document Findings:** For each flaw, note its `description`, `severity`,
+    `location_in_product`, and `blueprint_requirement_violated`. Assign a
+    unique `flaw_id`.
+4.  **Calculate/Contribute to Quality Score:** Based on your findings and the
+    defined metrics for the commission type. This involves populating
+    `quality_score.overall_score` and `quality_score.metrics_details`.
+5.  **Compile the Report:** Create the `inspection_report.json`, including
+    `commission_id`, `product_version_inspected`, `inspection_date`,
+    `lead_inspector_id`, `inspectors_involved`, the full `quality_score`
+    object, the list of `identified_flaws`, a `summary_assessment`, and a
+    final `recommendation` ('approve_for_delivery', 'requires_revision', or
+    'escalate_for_re_planning').
+6.  **Output:** Produce ONLY the `inspection_report.json` content, adhering
+    strictly to the official schema.
+"""
+
+# Note: Specialized inspector charters from Artisan_Charters.md (e.g., Spec
+# Compliance, Security Auditor) would provide more detailed instructions for
+# step 2 of the GENERAL_INSPECTOR_CHARTER_PROMPT. They can be added here as
+# separate prompts if the AI framework supports composing them, or their
+# content can be integrated into more specific versions of the general
+# inspector prompt for different agent roles. For this scaffolding phase, the
+# three main ones are included.
+
+if __name__ == '__main__':
+    print("Planner Charter:\n", PLANNER_CHARTER_PROMPT)
+    print("\nCoder Charter:\n", CODER_CHARTER_PROMPT)
+    print("\nGeneral Inspector Charter:\n", GENERAL_INSPECTOR_CHARTER_PROMPT)

--- a/gandalf_workshop/specs/__init__.py
+++ b/gandalf_workshop/specs/__init__.py
@@ -1,0 +1,12 @@
+"""
+Gandalf Workshop - Specifications Submodule
+
+This file makes the 'specs' directory a Python submodule.
+This is the "Technical Archives" of the workshop, where the precise
+definitions (schemas) for Blueprints and Inspection Reports are stored.
+Making it a submodule allows these critical data model definitions
+to be imported cleanly.
+"""
+from .data_models import BlueprintModel, InspectionReportModel
+
+__all__ = ["BlueprintModel", "InspectionReportModel"]

--- a/gandalf_workshop/workshop_manager.py
+++ b/gandalf_workshop/workshop_manager.py
@@ -1,0 +1,317 @@
+"""
+workshop_manager.py - The Office of the Workshop Manager (Orchestrator)
+
+This module houses the WorkshopManager class, the central intelligence of the
+Gandalf Workshop. The Manager oversees all operations, from commissioning new
+Blueprints to approving final Products for delivery. It's akin to the master
+artisan or foreman who directs the workflow, assigns tasks to specialized
+artisans (AI agents/crews), and ensures quality standards are met throughout
+the creation process.
+"""
+import json
+from pathlib import Path
+from typing import Optional, Dict
+
+# Metaphor: The WorkshopManager is the foreman of the artisan's workshop,
+# directing the flow of work and ensuring quality.
+
+
+class WorkshopManager:
+    """
+    The Workshop Manager directs the workflow of the Gandalf workshop,
+    commissioning tasks to various artisan crews (AI agent configurations)
+    and managing the lifecycle of a commission from initial request to
+    final product delivery.
+    """
+
+    def __init__(self):
+        """
+        Initializes the Workshop Manager.
+        Metaphor: The Manager arrives at the workshop, ready to oversee the
+        day's tasks. This might involve setting up connections to artisan
+        crews or loading configurations.
+        """
+        # Placeholder for future initialization logic,
+        # e.g., loading configurations, initializing connections to AI agent
+        # frameworks (CrewAI, AutoGen, etc.)
+        print("Workshop Manager initialized. Ready to accept commissions.")
+        pass
+
+    def commission_new_blueprint(self, user_prompt: str,
+                                 commission_id: str) -> Path:
+        """
+        Assigns a new Commission to a Planner Artisan to create a Blueprint.
+        Metaphor: "Manager gives client's request to the Head Draftsman."
+        Args:
+            user_prompt: The initial request from the client.
+            commission_id: A unique ID for this new commission.
+        Returns:
+            Path to the generated blueprint.yaml file in the /blueprints
+            directory.
+        """
+        # In a real implementation, this would:
+        # 1. Initialize a "Planner Crew" (e.g., using CrewAI).
+        # 2. Pass the user_prompt and commission_id to the crew.
+        # 3. The crew would generate the blueprint.yaml.
+        # 4. The path to the blueprint would be saved and returned.
+        print(f"Workshop Manager: Commissioning new blueprint for "
+              f"'{commission_id}' based on prompt: '{user_prompt[:50]}...'")
+
+        # Placeholder: Create a dummy blueprint file for scaffolding purposes
+        blueprint_dir = Path("gandalf_workshop/blueprints") / commission_id
+        blueprint_dir.mkdir(parents=True, exist_ok=True)
+        blueprint_path = blueprint_dir / "blueprint.yaml"
+        with open(blueprint_path, "w") as f:
+            f.write(f"# Blueprint for {commission_id}\n")
+            f.write(f"commission_id: {commission_id}\n")
+            f.write(f"user_prompt: {user_prompt}\n")
+            f.write("status: placeholder_blueprint\n")
+
+        print(f"Workshop Manager: Placeholder blueprint generated at "
+              f"{blueprint_path}")
+        return blueprint_path
+
+    def request_product_generation_or_revision(
+        self,
+        commission_id: str,
+        blueprint_path: Path,
+        current_product_path: Optional[Path] = None,
+        previous_inspection_report_path: Optional[Path] = None
+    ) -> Path:
+        """
+        Assigns a Coder Artisan (or team) to build or revise a Product
+        based on the Blueprint.
+        Metaphor: "Manager gives Blueprint to Master Craftsman for
+        construction or rework."
+        Args:
+            commission_id: The ID of the commission.
+            blueprint_path: Path to the relevant blueprint.yaml.
+            current_product_path: Path to the existing product if this is a
+                                  revision.
+            previous_inspection_report_path: Path to the last inspection
+                                             report detailing flaws.
+        Returns:
+            Path to the newly generated or revised product version in
+            /commissions_in_progress.
+        """
+        print(f"Workshop Manager: Requesting product generation/revision for "
+              f"'{commission_id}'.")
+        print(f"  Blueprint: {blueprint_path}")
+        if current_product_path:
+            print(f"  Revising existing product: {current_product_path}")
+        if previous_inspection_report_path:
+            print(f"  Using inspection report: "
+                  f"{previous_inspection_report_path}")
+
+        # Placeholder: Create a dummy product directory/file
+        product_dir = (Path("gandalf_workshop/commissions_in_progress") /
+                       commission_id / "product_v_scaffold")
+        product_dir.mkdir(parents=True, exist_ok=True)
+        product_file_path = product_dir / "product_content.txt"
+        with open(product_file_path, "w") as f:
+            f.write(f"Placeholder product for {commission_id}\n")
+            if current_product_path:
+                f.write(f"Based on revision of {current_product_path.name}\n")
+
+        print(f"Workshop Manager: Placeholder product generated at "
+              f"{product_file_path}")
+        # In reality, this would be a path to a directory or a main file
+        return product_file_path
+
+    def initiate_quality_inspection(
+        self,
+        commission_id: str,
+        product_to_inspect_path: Path,
+        blueprint_path: Path
+    ) -> Path:
+        """
+        Assigns an Inspector Artisan (or Red Team) to conduct a Quality
+        Inspection on a Product.
+        Metaphor: "Manager sends a finished piece to the Quality Control
+        Guild for assessment."
+        Args:
+            commission_id: The ID of the commission.
+            product_to_inspect_path: Path to the product version to be
+                                     inspected.
+            blueprint_path: Path to the blueprint for compliance checking.
+        Returns:
+            Path to the generated inspection_report.json in the
+            /quality_control_lab.
+        """
+        print(f"Workshop Manager: Initiating quality inspection for product "
+              f"'{product_to_inspect_path.name}' of commission "
+              f"'{commission_id}'.")
+        print(f"  Blueprint for reference: {blueprint_path}")
+
+        # Placeholder: Create a dummy inspection report
+        report_dir = Path("gandalf_workshop/quality_control_lab") / commission_id
+        report_dir.mkdir(parents=True, exist_ok=True)
+        # e.g. product_v1_inspection_report.json
+        report_name = (
+            f"{product_to_inspect_path.parent.name}_inspection_report.json"
+        )
+        report_path = report_dir / report_name
+
+        with open(report_path, "w") as f:
+            json.dump({
+                "commission_id": commission_id,
+                "product_version_inspected": product_to_inspect_path.parent.name,
+                "status": "placeholder_inspection_report",
+                "summary": "Scaffold report - no actual inspection performed."
+            }, f, indent=2)
+
+        print(f"Workshop Manager: Placeholder inspection report generated at "
+              f"{report_path}")
+        return report_path
+
+    def finalize_commission_and_deliver(
+        self,
+        commission_id: str,
+        final_product_path: Path,
+        final_inspection_report_path: Path
+    ) -> None:
+        """
+        Packages the final Product and its Inspection Report for delivery
+        (e.g., to /completed_commissions).
+        Metaphor: "Manager approves the final Product, archives records, and
+        prepares it for the client."
+        Args:
+            commission_id: The ID of the commission.
+            final_product_path: Path to the approved final product.
+            final_inspection_report_path: Path to the final inspection report.
+        """
+        print(f"Workshop Manager: Finalizing commission '{commission_id}'.")
+        print(f"  Final Product: {final_product_path}")
+        print(f"  Final Inspection Report: {final_inspection_report_path}")
+
+        # Placeholder: Simulate moving to completed_commissions
+        # In a real scenario, this would involve copying files/directories.
+        completed_dir = (Path("gandalf_workshop/completed_commissions") /
+                         commission_id)
+        completed_dir.mkdir(parents=True, exist_ok=True)
+
+        # Simulate copying product
+        # (if it's a file, more complex if it's a dir)
+        # For this scaffold, let's assume final_product_path is a file.
+        if final_product_path.is_file():
+            dest_product_name = f"final_product_{final_product_path.name}"
+            with open(completed_dir / dest_product_name, "w") as f:
+                f.write(f"Simulated copy of {final_product_path.name} for "
+                        f"commission {commission_id}\n")
+        else:  # if it's a directory
+            dest_info_name = (f"final_product_info_for_"
+                              f"{final_product_path.name}.txt")
+            with open(completed_dir / dest_info_name, "w") as f:
+                f.write(f"Simulated copy of product directory "
+                        f"{final_product_path} for commission {commission_id}\n")
+
+        # Simulate copying inspection report
+        dest_report_name = (f"final_inspection_report_"
+                            f"{final_inspection_report_path.name}")
+        with open(completed_dir / dest_report_name, "w") as f:
+            f.write(f"Simulated copy of {final_inspection_report_path.name} "
+                    f"for commission {commission_id}\n")
+
+        print(f"Workshop Manager: Commission '{commission_id}' finalized and "
+              f"artifacts 'moved' to {completed_dir}.")
+        pass
+
+    def request_blueprint_revision(
+        self,
+        commission_id: str,
+        original_blueprint_path: Path,
+        failure_history: Dict[str, any]
+    ) -> Path:
+        """
+        When a Commission is failing due to fundamental design issues, sends
+        it back to a Planner Artisan to revise the original Blueprint.
+        (Corresponds to Tier 2 Regression Protocol Re-Plan).
+        Metaphor: "Manager sends a flawed design back to the Design Studio
+        with notes on what went wrong."
+        Args:
+            commission_id: The ID of the commission.
+            original_blueprint_path: Path to the blueprint that needs
+                                     revision.
+            failure_history: Data about why the current blueprint is failing.
+        Returns:
+            Path to the revised blueprint.yaml.
+        """
+        print(f"Workshop Manager: Requesting blueprint revision for "
+              f"'{commission_id}'.")
+        print(f"  Original Blueprint: {original_blueprint_path}")
+        print(f"  Failure History: {failure_history}")
+
+        # Placeholder: Create a dummy revised blueprint file
+        revised_blueprint_name = (
+            f"{original_blueprint_path.stem}_revised.yaml"
+        )
+        revised_blueprint_path = (original_blueprint_path.parent /
+                                  revised_blueprint_name)
+        with open(revised_blueprint_path, "w") as f:
+            f.write(f"# Revised Blueprint for {commission_id}\n")
+            f.write(f"commission_id: {commission_id}\n")
+            f.write("status: placeholder_revised_blueprint\n")
+            f.write(f"based_on_failures: {str(failure_history)}\n")
+
+        print(f"Workshop Manager: Placeholder revised blueprint generated at "
+              f"{revised_blueprint_path}")
+        return revised_blueprint_path
+
+
+if __name__ == "__main__":
+    # Example of how the manager might be used (for testing purposes)
+    manager = WorkshopManager()
+    test_commission_id = "test_commission_001"
+    test_prompt = "Create a simple command-line calculator."
+
+    # 1. Commission a new blueprint
+    bp_path = manager.commission_new_blueprint(
+        user_prompt=test_prompt,
+        commission_id=test_commission_id
+    )
+
+    # 2. Request product generation
+    # In a real flow, product_path would point to a directory or a set
+    # of files
+    product_path_v1 = manager.request_product_generation_or_revision(
+        commission_id=test_commission_id,
+        blueprint_path=bp_path
+    )
+    # Create a dummy product_v1 directory and file for the sake of example
+    # (manager.request_product_generation_or_revision already creates a
+    # placeholder file)
+    # So, product_path_v1 from the function is
+    # Path('gandalf_workshop/commissions_in_progress/test_commission_001/product_v_scaffold/product_content.txt')
+    # For initiate_quality_inspection, it expects product_to_inspect_path
+    # to be more like a versioned product.
+    # Let's adjust the path to simulate this structure for the test.
+    # The manager's placeholder creates
+    # .../product_v_scaffold/product_content.txt
+    # We need to pass the path to the file itself for the current scaffold.
+
+    # 3. Initiate quality inspection
+    inspection_report_v1_path = manager.initiate_quality_inspection(
+        commission_id=test_commission_id,
+        product_to_inspect_path=product_path_v1,  # Path to the actual product
+        blueprint_path=bp_path
+    )
+
+    # 4. (Optional) Request revision if inspection failed
+    # For this test, let's assume it passed or we skip to finalization
+
+    # 5. Finalize and deliver
+    manager.finalize_commission_and_deliver(
+        commission_id=test_commission_id,
+        final_product_path=product_path_v1,  # Assuming v1 is final
+        final_inspection_report_path=inspection_report_v1_path
+    )
+
+    # Example of blueprint revision
+    failure_data = {"reason": "Initial design too complex", "attempts": 2}
+    revised_bp_path = manager.request_blueprint_revision(
+        commission_id=test_commission_id,
+        original_blueprint_path=bp_path,
+        failure_history=failure_data
+    )
+    print(f"Process completed for {test_commission_id}. Revised blueprint at "
+          f"{revised_bp_path if revised_bp_path else 'N/A'}")

--- a/gandalf_workshop/workshop_manager.py
+++ b/gandalf_workshop/workshop_manager.py
@@ -35,7 +35,6 @@ class WorkshopManager:
         # e.g., loading configurations, initializing connections to AI agent
         # frameworks (CrewAI, AutoGen, etc.)
         print("Workshop Manager initialized. Ready to accept commissions.")
-        pass
 
     def commission_new_blueprint(self, user_prompt: str,
                                  commission_id: str) -> Path:
@@ -214,7 +213,6 @@ class WorkshopManager:
 
         print(f"Workshop Manager: Commission '{commission_id}' finalized and "
               f"artifacts 'moved' to {completed_dir}.")
-        pass
 
     def request_blueprint_revision(
         self,

--- a/main.py
+++ b/main.py
@@ -1,0 +1,81 @@
+"""
+main.py - The Main Entrance to the Gandalf Workshop
+
+This script serves as the primary command-line interface for interacting with
+the Gandalf Workshop. It's like the front gate where clients arrive to submit
+new commissions. Upon receiving a request (a "prompt"), this script will
+initialize the WorkshopManager and instruct it to begin the process, starting
+with the creation of a Blueprint.
+"""
+import argparse
+import uuid
+from pathlib import Path
+
+from gandalf_workshop.workshop_manager import WorkshopManager
+
+# Metaphor: This is the main reception desk or commission intake point of the
+# workshop. A client (user) arrives with a request (prompt), and the process
+# begins here.
+
+
+def main():
+    """
+    Main function to handle command-line arguments and initiate a new commission.
+    Metaphor: The chief clerk receives a new commission request from a client,
+    assigns it a unique tracking number, and forwards it to the Workshop
+    Manager to commence the design phase (Blueprint creation).
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Gandalf Workshop CLI - Submit a new commission."
+        )
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        required=True,
+        help="The user's request or description for the new commission."
+    )
+    # Potentially add more arguments later, e.g., --commission_id,
+    # --config_file
+
+    args = parser.parse_args()
+
+    print("Gandalf Workshop: Received new commission request.")
+
+    # Initialize the Workshop Manager
+    # Metaphor: The Workshop Manager is summoned to oversee the new commission.
+    manager = WorkshopManager()
+
+    # Generate a unique commission ID
+    # Metaphor: A unique serial number is stamped onto the new commission's
+    # docket.
+    commission_id = f"commission_{uuid.uuid4().hex[:8]}"
+    print(f"Gandalf Workshop: Assigning Commission ID: {commission_id}")
+
+    user_prompt = args.prompt
+    print(f"Gandalf Workshop: User Prompt: \"{user_prompt}\"")
+
+    # Call the Workshop Manager's primary method to start the process
+    # Metaphor: The Manager is instructed to assign the new commission to the
+    #           Planner Artisans to begin drafting the Blueprint.
+    try:
+        blueprint_path: Path = manager.commission_new_blueprint(
+            user_prompt=user_prompt,
+            commission_id=commission_id
+        )
+        print(f"Gandalf Workshop: New commission '{commission_id}' has been "
+              f"accepted.")
+        print(f"Blueprint creation process has begun. Placeholder Blueprint "
+              f"at: {blueprint_path.resolve()}")
+        print("Further steps (product generation, inspection) would follow "
+              "based on this blueprint.")
+    except Exception as e:
+        print(f"Gandalf Workshop: An error occurred while processing the "
+              f"commission: {e}")
+        # Add more sophisticated error handling or logging here
+
+
+if __name__ == "__main__":
+    # Metaphor: The workshop doors are opened, ready for new commissions.
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pydantic>=1.8,<2.0 # Pinning to Pydantic v1 for now as v2 has breaking changes, and original examples used v1 .json()
+# Add other core dependencies here as they become necessary, for example:
+# crewai
+# python-dotenv
+# langchain
+#
+# For development and testing:
+# pytest
+# flake8


### PR DESCRIPTION
Creates the complete directory structure for the Gandalf workshop. Defines Pydantic models for Blueprint and InspectionReport. Scaffolds the WorkshopManager class with all conceptual methods. Sets up Artisan charters as prompts and placeholder artisan initialization functions. Creates a main.py CLI entrypoint to commission new blueprints. Adds requirements.txt and necessary __init__.py files. Ensures basic PEP8 compliance and metaphorical docstrings throughout.