### PR TITLE
Fix: Prevent EOF SyntaxError and correct Makefile prompt quoting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for the Gandalf Trust Framework
 
 # Ensure that PROMPT is set, but allow it to be overridden from the command line
-PROMPT ?= "a simple CLI tool that takes a name and prints a greeting"
+PROMPT ?= a simple CLI tool that takes a name and prints a greeting
 AUDIT_APP_NAME ?= app
 
 # Default target


### PR DESCRIPTION
- Defensively rewrote crews_hardcoded.py and llm_manager.py to prevent potential EOF SyntaxErrors caused by file writing artifacts.
- Modified Makefile to correctly quote the default PROMPT variable, preventing argument parsing errors in run_commission.py.

The make develop command now proceeds past the point of import errors, but fails due to missing API keys (an environmental configuration issue).