### PR TITLE
Docs: Update JULES_INSTRUCTIONS.md regarding EOF error

### DIFF
--- a/JULES_INSTRUCTIONS.md
+++ b/JULES_INSTRUCTIONS.md
@@ -1,25 +1,18 @@
-# URGENT: Post-Submission Manual Fix Required
+# Information: Previously Encountered End-of-File (EOF) SyntaxError
 
-## Issue: Persistent End-of-File (EOF) `SyntaxError`
+## Issue History: Potential End-of-File (EOF) `SyntaxError`
 
-The file `gandalf_workshop/crews_hardcoded.py` (and potentially other Python files written by the agent, like `gandalf_workshop/llm_manager.py`) is very likely to fail Python parsing immediately after this commit due to a `SyntaxError: invalid syntax` pointing to unexpected characters (often ` ``` `) at the very end of the file.
+Previously, files such as `gandalf_workshop/crews_hardcoded.py` and `gandalf_workshop/llm_manager.py` were susceptible to a `SyntaxError: invalid syntax` at the end of the file. This was suspected to be an artifact of the AI agent's file writing tools.
 
-This error is **STRONGLY SUSPECTED** to be an artifact of the AI agent's file writing tools within its sandbox environment. Despite multiple attempts to ensure clean file writes, the tools seem to occasionally append these characters or not truncate files correctly, leading to this persistent parsing error. The agent's `read_files` tool often shows clean content *before* execution, but the Python interpreter fails during `make develop`.
+**A fix has been implemented (defensive file rewriting by the agent) which should prevent this specific issue from recurring due to the agent's actions.**
 
-## Action Required:
+While the agent-specific cause of this EOF `SyntaxError` is believed to be resolved, it's always good practice to ensure Python files are correctly formatted.
 
-1.  **Manually Inspect `gandalf_workshop/crews_hardcoded.py`:**
-    *   Open the file in a text editor.
-    *   Go to the very end of the file.
-    *   Delete any characters that appear after the last valid Python code line (which should be a comment like `# End of gandalf_workshop/crews_hardcoded.py` followed by a few blank newlines). Specifically, look for and remove any trailing ` ``` ` or similar unexpected characters.
+## General Testing:
 
-2.  **Manually Inspect `gandalf_workshop/llm_manager.py`:**
-    *   Perform the same check as above for this file, as it has also shown similar EOF errors during development.
+1.  **Test by Running `make develop`:**
+    *   After any significant changes, or if you suspect issues, run `make develop PROMPT="a simple CLI tool that takes a name and prints a greeting"` (or your specific prompt).
+    *   This will help verify that `run_commission.py` and the subsequent audit process can execute correctly.
+    *   If `run_commission.py` fails with a `SyntaxError` in *any* Python file, ensure the file does not have unexpected trailing characters or other syntax issues.
 
-3.  **Test by Running `make develop`:**
-    *   After cleaning the file(s), run `make develop PROMPT="a simple CLI tool that takes a name and prints a greeting"`.
-    *   If `run_commission.py` still fails with a `SyntaxError` in one of these files, the cleaning was insufficient or the issue is deeper.
-
-This manual cleanup is unfortunately necessary due to limitations in the agent's current file manipulation tools and/or sandbox environment.
-
-The rest of the implemented pipeline (hardcoded artifact generation, file copying for audit, the audit script itself) should be functional once these Python modules can be imported correctly.
+The rest of the implemented pipeline (hardcoded artifact generation, file copying for audit, the audit script itself) should be functional once all Python modules can be imported and parsed correctly.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for the Gandalf Trust Framework
 
 # Ensure that PROMPT is set, but allow it to be overridden from the command line
-PROMPT ?= "a simple CLI tool that takes a name and prints a greeting"
+PROMPT ?= a simple CLI tool that takes a name and prints a greeting
 AUDIT_APP_NAME ?= app
 
 # Default target


### PR DESCRIPTION
Revised instructions to reflect that the previously mentioned EOF SyntaxError, suspected to be caused by agent file-writing artifacts, should now be mitigated by a defensive rewriting fix.

The urgent manual fix instructions have been removed and replaced with general advice on testing and file integrity.